### PR TITLE
Autoencoder features

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Once `conda` is installed and set up, install dependencies with (warning: this s
 conda env create -f environment.yml -p <path to install conda env>
 ```
 
-One package cannot be installed via `conda` and needs to be installed with `pip` (after activating your `conda` env above):
+Some packages cannot be installed via `conda` or take too long and need to be installed with `pip` (after activating your `conda` env above):
 ```
 pip install yahist
+pip install tensorflow==2.5
 ```
 
 Note: if you are running on `lxplus`, you may run into permissions errors, which may be fixed with:

--- a/autodqm_ml/algorithms/autoencoder.py
+++ b/autodqm_ml/algorithms/autoencoder.py
@@ -98,6 +98,10 @@ class AutoEncoder(MLAlgorithm):
                     axis = -1
             )
 
+            # For 2d histograms, we need to sum over one more axis to get a single SSE score for each run
+            if histogram_info["n_dim"] == 2:
+                sse = awkward.sum(sse, axis = -1)
+
             self.add_prediction(histogram, sse, reconstructed_hist)
             idx += 1
 

--- a/autodqm_ml/algorithms/autoencoder.py
+++ b/autodqm_ml/algorithms/autoencoder.py
@@ -34,6 +34,7 @@ class AutoEncoder(MLAlgorithm):
                 new = self.__dict__
         )
 
+
     def load_model(self, model_file):
         """
 
@@ -47,6 +48,7 @@ class AutoEncoder(MLAlgorithm):
 
         """
         model.save(model_file)
+
 
     def train(self, n_epochs = 1000, batch_size = 128):
         """
@@ -86,7 +88,10 @@ class AutoEncoder(MLAlgorithm):
         idx = 0
         for histogram, histogram_info in self.histograms.items():
             original_hist = self.df[histogram]
-            reconstructed_hist = awkward.flatten(awkward.from_numpy(pred[idx]), axis = -1) 
+            if len(self.histograms.items()) >= 2:
+                reconstructed_hist = awkward.flatten(awkward.from_numpy(pred[idx]), axis = -1) 
+            else:
+                reconstructed_hist = awkward.flatten(awkward.from_numpy(pred), axis = -1)
 
             sse = awkward.sum(
                     (original_hist - reconstructed_hist) ** 2,
@@ -95,6 +100,7 @@ class AutoEncoder(MLAlgorithm):
 
             self.add_prediction(histogram, sse, reconstructed_hist)
             idx += 1
+
 
     def make_inputs(self, split = None):
         """

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,6 @@ dependencies:
   - scipy
   - matplotlib
   - tqdm
-  - sklearn
+  - scikit-learn
   - sphinx
   - sphinx_rtd_theme


### PR DESCRIPTION
Fix a couple bugs in autoencoders:
- shape mismatch in SSE evaluation when training just a single histogram
- shape mismatch in SSE evaluation when training 2d histograms