### PR TITLE
Developments for autoencoders and assess script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,10 @@ and then rerunning the command to create the `conda` env. The resulting `conda e
 
 **3. Install autodqm-ml**
 
-**Users** can install with:
-```
-python setup.py install
-```
-**Developers** are suggested to install with:
+Install with:
 ```
 pip install -e .
 ```
-to avoid rerunning the whole installation every time there is a change.
 
 Once your setup is installed, you can activate your python environment with
 ```

--- a/autodqm_ml/algorithms/anomaly_detection_algorithm.py
+++ b/autodqm_ml/algorithms/anomaly_detection_algorithm.py
@@ -72,6 +72,7 @@ class AnomalyDetectionAlgorithm():
 
         if histograms:
             self.histograms = histograms
+        self.histogram_name_map = {} # we replace "/" and spaces in input histogram names to play nicely with other packages, this map lets you go back and forth between them
 
         logger.debug("[AnomalyDetectionAlgorithm : load_data] Loading training data from file '%s'" % (self.input_file))
 
@@ -81,6 +82,7 @@ class AnomalyDetectionAlgorithm():
         # Set helpful metadata
         for histogram, histogram_info in self.histograms.items():
             self.histograms[histogram]["name"] = histogram.replace("/", "").replace(" ","")
+            self.histogram_name_map[self.histograms[histogram]["name"]] = histogram
 
             a = awkward.to_numpy(df[histogram][0])
             self.histograms[histogram]["shape"] = a.shape
@@ -134,9 +136,9 @@ class AnomalyDetectionAlgorithm():
         self.n_train = awkward.sum(df.train_label == 0)
         self.n_test = awkward.sum(df.train_label == 1)
         self.df = df
+        self.n_histograms = len(list(self.histograms.keys()))
 
-
-        logger.debug("[AnomalyDetectionAlgorithm : load_data] Loaded data for %d histograms with %d events in training set and %d events in testing set." % (len(list(self.histograms.keys())), self.n_train, self.n_test))
+        logger.debug("[AnomalyDetectionAlgorithm : load_data] Loaded data for %d histograms with %d events in training set and %d events in testing set." % (self.n_histograms, self.n_train, self.n_test))
 
         self.data_is_loaded = True
 

--- a/autodqm_ml/algorithms/anomaly_detection_algorithm.py
+++ b/autodqm_ml/algorithms/anomaly_detection_algorithm.py
@@ -2,6 +2,7 @@ import os
 import pandas
 import numpy
 import awkward
+import json
 
 from autodqm_ml import utils
 from autodqm_ml.data_formats.histogram import Histogram
@@ -162,3 +163,13 @@ class AnomalyDetectionAlgorithm():
         self.output_file = "%s/%s.parquet" % (self.output_dir, self.input_file.split("/")[-1].replace(".parquet", ""))
         logger.info("[AnomalyDetectionAlgorithm : save] Saving output with additional fields to file '%s'." % (self.output_file))
         awkward.to_parquet(self.df, self.output_file)
+
+        self.config_file = "%s/%s_%s.json" % (self.output_dir, self.name, self.tag)
+        config = {}
+        for k,v in vars(self).items():
+            if utils.is_json_serializable(v):
+                config[k] = v
+
+        logger.info("[AnomalyDetectionAlgorithm : save] Saving AnomalyDetectionAlgorithm config to file '%s'." % (self.config_file))
+        with open(self.config_file, "w") as f_out:
+            json.dump(config, f_out, sort_keys = True, indent = 4)

--- a/autodqm_ml/algorithms/autoencoder.py
+++ b/autodqm_ml/algorithms/autoencoder.py
@@ -15,13 +15,13 @@ from autodqm_ml.algorithms.ml_algorithm import MLAlgorithm
 from autodqm_ml import utils
 
 DEFAULT_OPT = {
-        "batch_size" : 16, 
+        "batch_size" : 128, 
         "val_batch_size" : 1024,
         "n_epochs" : 1000,
         "early_stopping" : True,
         "early_stopping_rounds" : 3,
         "n_hidden_layers" : 2,
-        "n_nodes" : 25,
+        "n_nodes" : 50,
         "n_components" : 3,
         "kernel_1d" : 3,
         "kernel_2d" : 3,
@@ -29,7 +29,7 @@ DEFAULT_OPT = {
         "strides_2d" : 1,
         "dropout" : 0.0,
         "batch_norm" : False,
-        "n_filters" : 8
+        "n_filters" : 12
 }
 
 class AutoEncoder(MLAlgorithm):
@@ -167,32 +167,6 @@ class AutoEncoder(MLAlgorithm):
 
                 self.add_prediction(hist_name, sse, reconstructed_hist) 
  
-            """
-            idx = 0
-            for histogram, histogram_info in self.histograms.items():
-                original_hist = self.df[histogram]
-                if self.n_histograms >= 2: 
-                    #reconstructed_hist = awkward.flatten(
-                    #        awkward.from_numpy(pred["output_" + histogram_info["name"]]),
-                    #        axis = -1
-                    #)
-                    reconstructed_hist = awkward.flatten(awkward.from_numpy(pred[idx]), axis = -1) 
-                else:
-                    #reconstructed_hist = awkward.flatten(awkward.from_numpy(pred), axis = -1)
-
-                sse = awkward.sum(
-                        (original_hist - reconstructed_hist) ** 2,
-                        axis = -1
-                )
-
-                # For 2d histograms, we need to sum over one more axis to get a single SSE score for each run
-                if histogram_info["n_dim"] == 2:
-                    sse = awkward.sum(sse, axis = -1)
-
-                self.add_prediction(histogram, sse, reconstructed_hist)
-                idx += 1
-            """
-
 
     def make_inputs(self, split = None, histogram_name = None):
         """
@@ -224,16 +198,11 @@ class AutoEncoder(MLAlgorithm):
         return inputs, outputs
 
 
-#class AutoEncoder_DNN(keras.models.Model):
 class AutoEncoder_DNN():
     """
-    Model defined through the Keras Model Subclassing API: https://www.tensorflow.org/guide/keras/custom_layers_and_models
-    An AutoEncoder instance owns a single AutoEncoder_DNN, which is the actual implementation of the DNN.
-
+    An AutoEncoder instance owns AutoEncoder_DNN(s), which is the actual implementation of the DNN.
     """
     def __init__(self, histograms, **kwargs): 
-        #super(AutoEncoder_DNN, self).__init__()
-
         self.n_histograms = len(histograms.keys())
 
         self.__dict__.update(kwargs)

--- a/autodqm_ml/algorithms/autoencoder.py
+++ b/autodqm_ml/algorithms/autoencoder.py
@@ -21,7 +21,7 @@ DEFAULT_OPT = {
         "early_stopping" : True,
         "early_stopping_rounds" : 3,
         "n_hidden_layers" : 2,
-        "n_nodes" : 10,
+        "n_nodes" : 25,
         "n_components" : 3,
         "kernel_1d" : 3,
         "kernel_2d" : 3,

--- a/autodqm_ml/algorithms/autoencoder.py
+++ b/autodqm_ml/algorithms/autoencoder.py
@@ -15,7 +15,7 @@ from autodqm_ml.algorithms.ml_algorithm import MLAlgorithm
 from autodqm_ml import utils
 
 DEFAULT_OPT = {
-        "batch_size" : 16,
+        "batch_size" : 16, 
         "val_batch_size" : 1024,
         "n_epochs" : 1000,
         "early_stopping" : True,
@@ -51,9 +51,13 @@ class AutoEncoder(MLAlgorithm):
 
         self.mode = kwargs.get('autoencoder_mode', 'individual')
         if not self.mode in ["individual", "simultaneous"]:
-            logger.exception("AutoEncoder : __init__] mode '%s' is not a recognized option for AutoEncoder. Currently available modes are 'individual' (default) and 'simultaneous'." % (self.mode))
+            logger.exception("[AutoEncoder : __init__] mode '%s' is not a recognized option for AutoEncoder. Currently available modes are 'individual' (default) and 'simultaneous'." % (self.mode))
             raise ValueError()
         self.models = {}
+
+        logger.debug("[AutoEncoder : __init__] Constructing AutoEncoder with the following training options and hyperparameters:")
+        for param, value in self.config.items():
+            logger.debug("\t %s : %s" % (param, str(value)))
 
 
     def load_model(self, model_file):

--- a/autodqm_ml/algorithms/autoencoder.py
+++ b/autodqm_ml/algorithms/autoencoder.py
@@ -3,6 +3,7 @@ import pandas
 import numpy
 import json
 import awkward
+import copy
 
 import logging
 logger = logging.getLogger(__name__)
@@ -14,25 +15,45 @@ from autodqm_ml.algorithms.ml_algorithm import MLAlgorithm
 from autodqm_ml import utils
 
 DEFAULT_OPT = {
+        "batch_size" : 16,
+        "val_batch_size" : 1024,
+        "n_epochs" : 1000,
+        "early_stopping" : True,
+        "early_stopping_rounds" : 3,
         "n_hidden_layers" : 2,
-        "n_nodes" : 25,
+        "n_nodes" : 10,
         "n_components" : 3,
         "kernel_1d" : 3,
         "kernel_2d" : 3,
+        "strides_1d" : 1,
+        "strides_2d" : 1,
+        "dropout" : 0.0,
+        "batch_norm" : False,
         "n_filters" : 8
 }
 
 class AutoEncoder(MLAlgorithm):
     """
     Autoencoder base class.
+
+    :param config: dictionary with hyperparameters for autoencoder training. Any hyperparameters not specified will be taken from the default values in `DEFAULT_OPT`
+    :type config: dict
+    :param mode: string to specify whether you want to train an autoencoder for each histogram ("individual") or a single autoencoder on all histograms ("simultaneous")
+    :type mode: str
     """
     def __init__(self, **kwargs):
         super(AutoEncoder, self).__init__(**kwargs)
 
         self.config = utils.update_dict(
                 original = DEFAULT_OPT,
-                new = self.__dict__
+                new = kwargs.get('config', {})
         )
+
+        self.mode = kwargs.get('autoencoder_mode', 'individual')
+        if not self.mode in ["individual", "simultaneous"]:
+            logger.exception("AutoEncoder : __init__] mode '%s' is not a recognized option for AutoEncoder. Currently available modes are 'individual' (default) and 'simultaneous'." % (self.mode))
+            raise ValueError()
+        self.models = {}
 
 
     def load_model(self, model_file):
@@ -47,66 +68,129 @@ class AutoEncoder(MLAlgorithm):
         """
 
         """
+        logger.debug("[AutoEncoder : save_model] Saving trained autoencoder to file '%s'." % (model_file))
         model.save(model_file)
 
 
-    def train(self, n_epochs = 1000, batch_size = 128):
+    def train(self):
         """
 
         """
-        model_file = "%s/autoencoder_%s.h5" % (self.output_dir, self.tag)
-        if os.path.exists(model_file):
-            logger.warning("[AutoEncoder : train] A trained AutoEncoder alread exists with tag '%s' at file '%s'. We will load the saved model from the file rather than retraining. If you wish to retrain please provide a new tag or delete the old outputs." % (self.tag, model_file))
-            self.model = self.load_model(model_file)
-            return
+        if self.mode == "simultaneous":
+            self.models = { None : None }
+            logger.debug("[AutoEncoder : train] Mode selected as 'simultaneous', meaning a single autoencoder will be trained simultaneously on all histograms. Use 'individual' if you wish to train one autoencoder for each histogram.")
+        elif self.mode == "individual":
+            self.models = { k : None for k,v in self.histograms.items() } #copy.deepcopy(self.histograms)
+            logger.debug("[AutoEncoder : train] Mode selected as 'individual', meaning one autoencoder will be trained for each histogram. Use 'simultaneous' if you wish to train a single autoencoder for all histograms.")
 
-        inputs, outputs = self.make_inputs(split = "train")
-        inputs_val, outputs_val = self.make_inputs(split = "test")
+        for histogram, histogram_info in self.models.items():
+            if histogram is None:
+                model_file = "%s/autoencoder_%s.h5" % (self.output_dir, self.tag)
+            else:
+                model_file = "%s/autoencoder_%s_%s.h5" % (self.output_dir, histogram, self.tag)
+            
+            if os.path.exists(model_file):
+                logger.warning("[AutoEncoder : train] A trained AutoEncoder already exists with tag '%s' at file '%s'. We will load the saved model from the file rather than retraining. If you wish to retrain please provide a new tag or delete the old outputs." % (self.tag, model_file))
+                self.models[histogram] = self.load_model(model_file)
+                return
 
-        self.model = AutoEncoder_DNN(self.histograms, **self.config).model()
-       
-        self.model.compile(
-                optimizer = keras.optimizers.Adam(), 
-                loss = keras.losses.MeanSquaredError()
-        )
 
-        self.model.fit(
-                inputs,
-                outputs,
-                validation_data = (inputs_val, outputs_val),
-                callbacks = [keras.callbacks.EarlyStopping(patience = 3)],
-                epochs = n_epochs,
-                batch_size = batch_size
-        )
-        self.save_model(self.model, model_file)
+            inputs, outputs = self.make_inputs(split = "train", histogram_name = histogram)
+            inputs_val, outputs_val = self.make_inputs(split = "test", histogram_name = histogram)
+
+            if histogram is None:
+                hist_name = str(list(self.models.keys()))
+            else:
+                hist_name = histogram
+            logger.debug("[AutoEncoder : train] Training autoencoder with %d dimensions in latent space for histogram(s) '%s' with %d training examples." % (self.config["n_components"], hist_name, len(list(inputs.values())[0]))) 
+
+            if self.mode == "simultaneous":
+                histograms = self.histograms
+            elif self.mode == "individual":
+                histograms = { histogram : self.histograms[histogram] }
+
+            model = AutoEncoder_DNN(histograms, **self.config).model()
+           
+            model.compile(
+                    optimizer = keras.optimizers.Adam(), 
+                    loss = keras.losses.MeanSquaredError()
+            )
+
+            callbacks = []
+            if self.config["early_stopping"]:
+                callbacks.append(keras.callbacks.EarlyStopping(patience = self.config["early_stopping_rounds"))
+
+            model.fit(
+                    inputs,
+                    outputs,
+                    validation_data = (inputs_val, outputs_val),
+                    callbacks = callbacks, 
+                    epochs = self.config["n_epochs"],
+                    batch_size = self.config["batch_size"]
+            )
+            
+            self.save_model(model, model_file)
+            self.models[histogram] = model
 
     
     def predict(self, batch_size = 1024):
-        inputs, outputs = self.make_inputs(split = "all")
-        pred = self.model.predict(inputs, batch_size = batch_size)
+        for histogram, model in self.models.items():
+            inputs, outputs = self.make_inputs(split = "all", histogram_name = histogram)
+            predictions = model.predict(inputs, batch_size = batch_size)
 
-        idx = 0
-        for histogram, histogram_info in self.histograms.items():
-            original_hist = self.df[histogram]
-            if len(self.histograms.items()) >= 2:
-                reconstructed_hist = awkward.flatten(awkward.from_numpy(pred[idx]), axis = -1) 
+            if self.mode == "simultaneous" and self.n_histograms >= 2:
+                predictions = { name : pred for name, pred in zip(model.output_names, predictions) }
             else:
-                reconstructed_hist = awkward.flatten(awkward.from_numpy(pred), axis = -1)
+                predictions = { model.output_names[0] : predictions }
 
-            sse = awkward.sum(
-                    (original_hist - reconstructed_hist) ** 2,
-                    axis = -1
-            )
+            for name, pred in predictions.items():
+                hist_name = self.histogram_name_map[name.replace("output_", "")] # shape [n_runs, histogram dimensions, 1]
+                original_hist = self.df[hist_name] # shape [n_runs, histogram dimensions]
 
-            # For 2d histograms, we need to sum over one more axis to get a single SSE score for each run
-            if histogram_info["n_dim"] == 2:
-                sse = awkward.sum(sse, axis = -1)
+                reconstructed_hist = awkward.flatten( # change shape from [n_runs, histogram dimensions, 1] -> [n_runs, histogram dimensions]
+                        awkward.from_numpy(pred),
+                        axis = -1 
+                )
 
-            self.add_prediction(histogram, sse, reconstructed_hist)
-            idx += 1
+                sse = awkward.sum( # perform sum along inner-most axis, i.e. first histogram dimension
+                        (original_hist - reconstructed_hist) ** 2,
+                        axis = -1
+                )
+                
+                # For 2d histograms, we need to sum over one more axis to get a single SSE score for each run
+                if self.histograms[hist_name]["n_dim"] == 2:
+                    sse = awkward.sum(sse, axis = -1) # second histogram dimension
+
+                self.add_prediction(hist_name, sse, reconstructed_hist) 
+ 
+            """
+            idx = 0
+            for histogram, histogram_info in self.histograms.items():
+                original_hist = self.df[histogram]
+                if self.n_histograms >= 2: 
+                    #reconstructed_hist = awkward.flatten(
+                    #        awkward.from_numpy(pred["output_" + histogram_info["name"]]),
+                    #        axis = -1
+                    #)
+                    reconstructed_hist = awkward.flatten(awkward.from_numpy(pred[idx]), axis = -1) 
+                else:
+                    #reconstructed_hist = awkward.flatten(awkward.from_numpy(pred), axis = -1)
+
+                sse = awkward.sum(
+                        (original_hist - reconstructed_hist) ** 2,
+                        axis = -1
+                )
+
+                # For 2d histograms, we need to sum over one more axis to get a single SSE score for each run
+                if histogram_info["n_dim"] == 2:
+                    sse = awkward.sum(sse, axis = -1)
+
+                self.add_prediction(histogram, sse, reconstructed_hist)
+                idx += 1
+            """
 
 
-    def make_inputs(self, split = None):
+    def make_inputs(self, split = None, histogram_name = None):
         """
 
         """
@@ -123,21 +207,28 @@ class AutoEncoder(MLAlgorithm):
         df = self.df[cut]
 
         for histogram, info in self.histograms.items():
+            if histogram_name is not None: # self.mode == "individual", i.e. separate autoencoder for each histogram
+                if not histogram == histogram_name: # only grab the relevant histogram for this autoencoder
+                    continue
+
             data = tf.convert_to_tensor(df[histogram])
             inputs["input_" + info["name"]] = data
             outputs["output_" + info["name"]] = data
 
+        
+
         return inputs, outputs
 
 
-class AutoEncoder_DNN(keras.models.Model):
+#class AutoEncoder_DNN(keras.models.Model):
+class AutoEncoder_DNN():
     """
     Model defined through the Keras Model Subclassing API: https://www.tensorflow.org/guide/keras/custom_layers_and_models
     An AutoEncoder instance owns a single AutoEncoder_DNN, which is the actual implementation of the DNN.
 
     """
     def __init__(self, histograms, **kwargs): 
-        super(AutoEncoder_DNN, self).__init__()
+        #super(AutoEncoder_DNN, self).__init__()
 
         self.n_histograms = len(histograms.keys())
 
@@ -179,7 +270,11 @@ class AutoEncoder_DNN(keras.models.Model):
 
 
     def model(self):
-        model = keras.models.Model(inputs = self.inputs, outputs = self.outputs)
+        model = keras.models.Model(
+                inputs = self.inputs,
+                outputs = self.outputs,
+                name = "autoencoder"
+        )
         model.summary()
         return model
 
@@ -209,7 +304,12 @@ class AutoEncoder_DNN(keras.models.Model):
                         activation = "relu",
                         name = name
                 )(layer)
-        
+            if self.batch_norm:
+                layer = keras.layers.BatchNormalization(name = name + "_batch_norm")
+            if self.dropout > 0:
+                layer = keras.layers.Dropout(self.dropout, name = name + "_dropout")
+
+
         encoder = keras.layers.Flatten()(layer)
         return input, encoder
 
@@ -229,10 +329,14 @@ class AutoEncoder_DNN(keras.models.Model):
                 activation = "relu"
                 n_filters = 1
                 name = "output_%s" % (info["name"])
+                batch_norm = False
+                dropout = 0
             else:
                 activation = "relu"
                 n_filters = self.n_filters 
                 name = "decoder_%d_%s" % (i, info["name"])
+                batch_norm = self.batch_norm
+                dropout = self.dropout
 
             if info["n_dim"] == 1:
                 layer = keras.layers.Conv1DTranspose(
@@ -252,6 +356,10 @@ class AutoEncoder_DNN(keras.models.Model):
                         activation = activation,
                         name = name
                 )(layer)
+            if batch_norm:
+                layer = keras.layers.BatchNormalization(name = name + "_batch_norm")
+            if dropout > 0:
+                layer = keras.layers.Dropout(self.dropout, name = name + "_dropout") 
 
         output = layer
         return output

--- a/autodqm_ml/algorithms/autoencoder.py
+++ b/autodqm_ml/algorithms/autoencoder.py
@@ -17,6 +17,7 @@ from autodqm_ml import utils
 DEFAULT_OPT = {
         "batch_size" : 128, 
         "val_batch_size" : 1024,
+        "learning_rate" : 0.001,
         "n_epochs" : 1000,
         "early_stopping" : True,
         "early_stopping_rounds" : 3,
@@ -50,6 +51,9 @@ class AutoEncoder(MLAlgorithm):
         )
 
         self.mode = kwargs.get('autoencoder_mode', 'individual')
+        if self.mode is None:
+            self.mode = "individual"
+
         if not self.mode in ["individual", "simultaneous"]:
             logger.exception("[AutoEncoder : __init__] mode '%s' is not a recognized option for AutoEncoder. Currently available modes are 'individual' (default) and 'simultaneous'." % (self.mode))
             raise ValueError()
@@ -116,7 +120,7 @@ class AutoEncoder(MLAlgorithm):
             model = AutoEncoder_DNN(histograms, **self.config).model()
            
             model.compile(
-                    optimizer = keras.optimizers.Adam(), 
+                    optimizer = keras.optimizers.Adam(learning_rate = self.config["learning_rate"]), 
                     loss = keras.losses.MeanSquaredError()
             )
 

--- a/autodqm_ml/algorithms/autoencoder.py
+++ b/autodqm_ml/algorithms/autoencoder.py
@@ -118,7 +118,7 @@ class AutoEncoder(MLAlgorithm):
 
             callbacks = []
             if self.config["early_stopping"]:
-                callbacks.append(keras.callbacks.EarlyStopping(patience = self.config["early_stopping_rounds"))
+                callbacks.append(keras.callbacks.EarlyStopping(patience = self.config["early_stopping_rounds"]))
 
             model.fit(
                     inputs,

--- a/autodqm_ml/algorithms/autoencoder.py
+++ b/autodqm_ml/algorithms/autoencoder.py
@@ -118,7 +118,7 @@ class AutoEncoder(MLAlgorithm):
         elif split == "test":
             cut = self.df.train_label == 1
         else:
-            cut = self.df.train_label >= 0
+            cut = self.df.run_number >= 0 # dummy all True cut
 
         df = self.df[cut]
 

--- a/autodqm_ml/algorithms/pca.py
+++ b/autodqm_ml/algorithms/pca.py
@@ -64,6 +64,8 @@ class PCA(MLAlgorithm):
         :param model_file: folder name to place trained PCA pickles
         :type model_file: str
         """
+        logger.debug("[PCA : save_model] Saving trained PCA to file '%s'." % (model_file))
+
         os.system("mkdir -p %s" % self.output_dir)
         pcaParams = {
                 'name' : model_file.split("/")[-1].replace(".json", ""),
@@ -141,7 +143,6 @@ class PCA(MLAlgorithm):
             pca.fit(input)
             self.model[histogram] = pca
             
-            logger.debug("[PCA : train] Saving trained PCA to file '%s'." % (model_file))
             self.save_model(pca, model_file)
 
     

--- a/autodqm_ml/evaluation/roc_tools.py
+++ b/autodqm_ml/evaluation/roc_tools.py
@@ -1,0 +1,111 @@
+import numpy
+import random
+from sklearn import metrics
+from tqdm import tqdm
+
+import logging
+logger = logging.getLogger(__name__)
+
+def calc_auc(y, pred, sample_weight = None, interp = 10000):
+    """
+    Make interpolated roc curve and calculate AUC.
+    Keyword arguments:
+    y -- array of labels
+    pred -- array of mva scores
+    sample_weight -- array of per-event weights
+    interp -- number of points in resulting fpr and tpr arrays
+    """
+
+    if sample_weight is None:
+        sample_weight = numpy.ones_like(y)
+
+    fpr, tpr, thresh = metrics.roc_curve(
+        y,
+        pred,
+        pos_label = 1,
+        sample_weight = sample_weight
+    )
+
+    fpr = sorted(fpr)
+    tpr = sorted(tpr)
+
+    fpr_interp = numpy.linspace(0, 1, interp)
+    tpr_interp = numpy.interp(fpr_interp, fpr, tpr) # recalculate tprs at each fpr
+
+    auc = metrics.auc(fpr, tpr)
+
+    results = {
+        "fpr" : fpr_interp,
+        "tpr" : tpr_interp,
+        "auc" : auc
+    }
+    return results
+
+def bootstrap_indices(x):
+    """
+    Return array of indices of len(x) to make bootstrap resamples 
+    """
+
+    return numpy.random.randint(0, len(x), len(x))
+    
+
+def calc_roc_and_unc(y, pred, sample_weight = None, n_bootstrap = 100, interp = 10000):
+    """
+    Calculates tpr and fpr arrays (with uncertainty for tpr) and auc and uncertainty
+    Keyword arguments:
+    y -- array of labels
+    pred -- array of mva scores
+    sample_weight -- array of per-event weights
+    n_bootstrap -- number of bootstrap resamples to use for calculating uncs
+    interp -- number of points in resulting fpr and tpr arrays
+    """
+
+    y = numpy.array(y)
+    pred = numpy.array(pred)
+
+    if sample_weight is None:
+        sample_weight = numpy.ones_like(y)
+    else:
+        sample_weight = numpy.array(sample_weight)
+
+    logger.debug("[roc_tools.py : calc_roc_and_unc] Calculating AUC and uncertainty with %d bootstrap samples." % (n_bootstrap))
+    results = calc_auc(y, pred, sample_weight)
+    fpr, tpr, auc = results["fpr"], results["tpr"], results["auc"]
+    
+    fprs = [fpr] 
+    tprs = [tpr]
+    aucs = [auc]
+
+    for i in tqdm(range(n_bootstrap)):
+        idx = bootstrap_indices(y)
+        
+        label_bootstrap   = y[idx]
+        pred_bootstrap    = pred[idx]
+        weights_bootstrap = sample_weight[idx]
+
+        results_bootstrap = calc_auc(label_bootstrap, pred_bootstrap, weights_bootstrap, interp)
+        fpr_b, tpr_b, auc_b = results_bootstrap["fpr"], results_bootstrap["tpr"], results_bootstrap["auc"]
+        fprs.append(fpr_b)
+        tprs.append(tpr_b)
+        aucs.append(auc_b)
+
+    unc = numpy.std(aucs)
+    tpr_mean = numpy.mean(tprs, axis=0)
+    tpr_unc = numpy.std(tprs, axis=0)
+    fpr_mean = numpy.mean(fprs, axis=0)
+
+    results = {
+        "auc" : auc,
+        "auc_unc" : unc,
+        "fpr" : fpr_mean,
+        "tpr" : tpr_mean,
+        "tpr_unc" : tpr_unc
+    }
+
+    return results
+
+
+def find_nearest(array,value):
+    val = numpy.ones_like(array)*value
+    idx = (numpy.abs(array-val)).argmin()
+    return array[idx], idx

--- a/autodqm_ml/plotting/plot_tools.py
+++ b/autodqm_ml/plotting/plot_tools.py
@@ -210,3 +210,48 @@ def plotMSESummary(original_hists, reconstructed_hists, threshold, hist_paths, r
     ax.text(1.1*max(mse), 0.5*max(hist), text, wrap=True, bbox=props)
     
     fig.savefig(f'plots/{algo}/MSE_Summary.png', bbox_inches='tight')
+
+
+def plot_roc_curve(h_name, results, save_name, **kwargs):
+    fig = plt.figure()
+    ax1 = fig.add_subplot(111)
+    ax1.yaxis.set_ticks_position('both')
+    ax1.grid(True)
+
+    log = kwargs.get("log", False)
+
+    idx = 0
+    for algo, res in results.items():
+        ax1.plot(
+                res["fpr"],
+                res["tpr"],
+                color = "C%d" % (idx+1),
+                label = algo + " [AUC = %.3f +/- %.3f]" % (res["auc"], res["auc_unc"])
+        )
+        ax1.fill_between(
+                res["fpr"],
+                res["tpr"] - (res["tpr_unc"] / 2.),
+                res["tpr"] + (res["tpr_unc"] / 2.),
+                color = "C%d" % (idx+1),
+                alpha = 0.25
+        )
+        idx += 1
+
+    if not log:
+        plt.ylim(0,1)
+        plt.xlim(0,1)
+    else:
+        plt.xlim(0.005, 1)
+        plt.ylim(0,1)
+        ax1.set_xscale("log")
+
+    plt.xlabel("False Anomaly Rate (FPR)")
+    plt.ylabel("Anomaly Detection Efficiency (TPR)")
+
+    legend = ax1.legend(loc='lower right')
+
+    logger.debug("[plot_tools.py : plot_roc_curve] Writing plot to file '%s'." % (save_name))
+    plt.savefig(save_name)
+    plt.savefig(save_name.replace(".pdf", ".png"))
+    plt.clf()
+

--- a/autodqm_ml/utils.py
+++ b/autodqm_ml/utils.py
@@ -6,6 +6,7 @@ Original author: Massimiliano Galli
 import os
 import copy
 import subprocess
+import json
 
 import logging
 from rich.logging import RichHandler
@@ -146,3 +147,12 @@ def check_proxy():
         return proxy
 
 
+def is_json_serializable(x):
+    """
+    Returns True if `x` is json serializable, False if not
+    """
+    try:
+        json.dumps(x)
+        return True
+    except:
+        return False

--- a/scripts/assess.py
+++ b/scripts/assess.py
@@ -153,6 +153,8 @@ def main(args):
                 make_sse_plot(h_name, recos, save_name)
 
             for algorithm, recos_alg in recos_by_label.items():
+                if not recos_alg:
+                    continue
                 save_name = args.output_dir + "/" + h_name + "_sse_%s_%s.pdf" % (algorithm, split)
                 make_sse_plot(h_name, recos_alg, save_name) 
 

--- a/scripts/assess.py
+++ b/scripts/assess.py
@@ -54,6 +54,12 @@ def parse_arguments():
         default = None
     )
     parser.add_argument(
+        "--make_webpage",
+        required=False,
+        action="store_true",
+        help="make a nicely browsable web page"
+    ) 
+    parser.add_argument(
         "--debug",
         help = "run logger in DEBUG mode (INFO is default)",
         required = False,
@@ -180,6 +186,12 @@ def main(args):
             save_name = args.output_dir + "/" + h_name + "_Run%d.pdf" % run_number
             make_original_vs_reconstructed_plot(h_name, original, recos, run_number, save_name) 
 
+    logger.info("[assess.py] Plots written to directory '%s'." % (args.output_dir))
+
+    if args.make_webpage:
+        os.system("cp web/index.php %s" % args.output_dir)
+        os.system("chmod 755 %s" % args.output_dir)
+        os.system("chmod 755 %s/*" % args.output_dir)
 
 if __name__ == "__main__":
     args = parse_arguments()

--- a/scripts/assess.py
+++ b/scripts/assess.py
@@ -7,7 +7,7 @@ import numpy
 from autodqm_ml.utils import setup_logger
 from autodqm_ml.utils import expand_path
 from autodqm_ml.plotting.plot_tools import make_original_vs_reconstructed_plot, make_sse_plot, plot_roc_curve
-from autodqm_ml.evaluation.roc_tools import calc_roc_and_unc
+from autodqm_ml.evaluation.roc_tools import calc_roc_and_unc, print_eff_table
 from autodqm_ml.constants import kANOMALOUS, kGOOD
 
 def parse_arguments():
@@ -179,7 +179,8 @@ def main(args):
             save_name = args.output_dir + "/" + h_name + "_roc.pdf"
             plot_roc_curve(h_name, roc_results[h], save_name)
             plot_roc_curve(h_name, roc_results[h], save_name.replace(".pdf", "_log.pdf"), log = True)
-
+            print_eff_table(h_name, roc_results[h])
+            
 
     # Plots of original/reconstructed histograms
     if args.runs is None:

--- a/scripts/assess.py
+++ b/scripts/assess.py
@@ -135,6 +135,7 @@ def main(args):
                 "label" : [("anomalous", kANOMALOUS), ("good", kGOOD)]
         }
         for split, split_info in splits.items():
+            recos_by_label = { k : {} for k,v in info["algorithms"].items() }
             for name, id in split_info:
                 runs_set = runs[runs[split] == id]
                 if len(runs_set) == 0:
@@ -143,19 +144,16 @@ def main(args):
                 recos = {}
                 for algorithm, algorithm_info in info["algorithms"].items():
                     recos[algorithm] = { "score" : runs_set[algorithm_info["score"]] }
+                    recos_by_label[algorithm][name] = { "score" : runs_set[algorithm_info["score"]] }
+
                 h_name = h.replace("/", "").replace(" ", "")
                 save_name = args.output_dir + "/" + h_name + "_sse_%s_%s.pdf" % (split, name)
                 make_sse_plot(h_name, recos, save_name)
 
+            for algorithm, recos_alg in recos_by_label.items():
+                save_name = args.output_dir + "/" + h_name + "_sse_%s_%s.pdf" % (algorithm, split)
+                make_sse_plot(h_name, recos_alg, save_name) 
 
-        #for set, id in zip(["train", "test"], [0, 1]):
-        #    runs_set = runs[runs.train_label == id]
-        #    recos = {}
-        #    for algorithm, algorithm_info in info["algorithms"].items():
-        #        recos[algorithm] = { "score" : runs_set[algorithm_info["score"]] }
-        #    h_name = h.replace("/", "").replace(" ", "")
-        #    save_name = args.output_dir + "/" + h_name + "_sse_%s.pdf" % set
-        #    make_sse_plot(h_name, recos, save_name)
 
     # Plots of original/reconstructed histograms
     if args.runs is None:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -59,6 +59,13 @@ parser.add_argument(
     default = None
 )
 parser.add_argument(
+    "--autoencoder_mode",
+    help = "specify whether you want to train an autoencoder for each histogram ('individual') or a single autoencoder on all histograms ('simultaneous')",
+    type = str,
+    required = False,
+    default = None
+)
+parser.add_argument(
     "--debug",
     help = "run logger in DEBUG mode (INFO is default)",
     required = False,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -10,25 +10,29 @@ from autodqm_ml.algorithms.autoencoder import AutoEncoder
 from autodqm_ml.utils import expand_path
 
 parser = argparse.ArgumentParser()
+
+# Required arguments
+parser.add_argument(
+    "--algorithm",
+    help = "name of algorithm ('PCA' or 'Autoencoder' or 'StatisticalTester') to train with default options OR path to json filed specifying particular options for training a given algorithm.",
+    type = str,
+    required = True
+)
+
+# Optional arguments
 parser.add_argument(
     "--output_dir",
     help = "output directory to place files in",
     type = str,
     required = False,
-    default = "output"
+    default = None
 )
 parser.add_argument(
     "--tag",
     help = "tag to identify output files",
     type = str,
     required = False,
-    default = "test"
-)
-parser.add_argument(
-    "--algorithm",
-    help = "name of algorithm ('PCA' or 'Autoencoder' or 'StatisticalTester') to train with default options OR path to json filed specifying particular options for training a given algorithm.",
-    type = str,
-    required = True
+    default = None
 )
 parser.add_argument(
     "--input_file",
@@ -126,8 +130,13 @@ else:
 
 if args.histograms is not None:
     histograms = {x : { "normalize" : True} for x in args.histograms.split(",")}
-else:
+elif isinstance(config["histograms"], str):
+    histograms = {x : { "normalize" : True} for x in config["histograms"].split(",")}
+elif isinstance(config["histograms"], dict):
     histograms = config["histograms"]
+else:
+    logger.exception("[train.py] The `histograms` argument should either be a csv list of histogram names (str) or a dictionary (if provided through a json config).")
+    raise RuntimeError()
 
 # Load data
 algorithm.load_data(

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -83,10 +83,16 @@ if "json" in args.algorithm:
     if not os.path.exists(args.algorithm):
         algorithm_config_file = expand_path(args.algorithm)
     else:
-        algorithm_config_file = algo
+        algorithm_config_file = args.algorithm
+
     with open(algorithm_config_file, "r") as f_in:
         config = json.load(f_in)
 
+    # Add command line arguments to config
+    for k,v in vars(args).items():
+        if v is not None:
+            config[k] = v # note: if you specify an argument both through command line argument and json, we give precedence to the version from command line arguments 
+    
 else:
     config = vars(args)
     config["name"] = args.algorithm.lower() 

--- a/scripts/web/README.md
+++ b/scripts/web/README.md
@@ -1,0 +1,1 @@
+The pretty web browser created from `index.php` is taken from Nick Amin's repo [niceplots](https://github.com/aminnj/niceplots).

--- a/scripts/web/index.php
+++ b/scripts/web/index.php
@@ -1,0 +1,642 @@
+<html>
+
+<head>
+
+<title>
+<?php
+$cwd = explode("/",getcwd());
+$folder = array_pop($cwd);
+echo $folder;
+?>
+</title>
+
+<!-- <script type="text/javascript" src="http://livejs.com/live.js"></script> -->
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script defer src="//code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.2.1/jstree.min.js"></script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/mark.js/8.11.1/jquery.mark.min.js"></script>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf.min.js"></script>
+<link defer rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.2.1/themes/default/style.min.css" />
+<link defer rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre.min.css">
+<link defer rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre-exp.min.css">
+<link defer rel="stylesheet" href="https://unpkg.com/spectre.css/dist/spectre-icons.min.css">
+<link rel="icon" type="image/png" href="../trashcan.png" />
+
+<style>
+
+mark {
+    padding: 0px;
+    color: #fff;
+    background: #4543dc;
+}
+
+#metadatacontainer {
+    position: fixed;
+    bottom: 0;
+    width: 97%;
+    padding: 10px; /* space between image and border */
+}
+#metadata {
+    border:0.1rem solid #999;
+    border-radius: 8px;
+    background-color: rgba(255, 255, 255, .96);
+    padding: 10px; /* space between image and border */
+}
+
+body {
+    font-family: sans-serif;
+    background-color: #fff;
+}
+body.dark-mode {
+    /* background-color: #000; */
+    background-color: #141414; /* 8% lightness 8*/
+}
+
+input[type=text] {
+}
+input[type=text].dark-mode {
+  background-color: #141414;
+  color: #dcdcdc;
+}
+
+button.dark-mode {
+  background-color: #141414;
+}
+
+.noborder {
+    border: none;
+    padding: 0px;
+    /* to take up full width without showing horizontal scrollbar */
+    width:90vw;
+}
+
+fieldset {
+    border:0.1rem solid #999;
+    border-radius: 8px;
+    margin: 1px;
+}
+fieldset.dark-mode {
+    border-color: #dcdcdc;
+}
+
+span.label.dark-mode {
+    border: 0.1rem solid #dcdcdc;
+    margin:-0.1rem;
+    color: #dcdcdc;
+    background: none;
+}
+
+#custom-handle {
+    width: 3em;
+    font-family: sans-serif;
+    text-align: center;
+}
+
+#slider {
+    float:right;
+    width: 10%;
+}
+
+
+.box {
+    float:left;
+    padding: 3px; /* space between image and border */
+}
+
+.plot {
+    color: #070;
+    text-decoration: none;
+    border-bottom: 2px solid #bdb;
+}
+
+#images {
+    position:relative;
+    padding-top: 10px;
+}
+
+#container {
+    margin: 1%;
+}
+
+.innerimg {
+    padding: 3px;
+}
+.innerimg.dark-mode {
+    filter: hue-rotate(180deg) invert(0.92); /* 8% lightness */
+    -webkit-filter: hue-rotate(180deg) invert(0.92);
+}
+.innerimg.super-saturate {
+    filter: saturate(2.5);
+    -webkit-filter: saturate(2.5);
+}
+.innerimg.dark-mode-super-saturate {
+    filter: hue-rotate(180deg) invert(0.92) saturate(2.5);
+    -webkit-filter: hue-rotate(180deg) invert(0.92) saturate(2.5);
+}
+
+
+legend {
+    font-weight: bold;
+    font-size: 90%;
+    margin: 0px;
+}
+legend.dark-mode {
+    color: #dcdcdc;
+}
+
+a {
+}
+a.dark-mode {
+    color: #55f;
+}
+
+
+</style>
+
+<?php
+
+// get flat list with parent references
+$data = array();
+function fillArrayWithFileNodes( DirectoryIterator $dir , $theParent="#") {
+    global $data;
+    foreach ( $dir as $node ) {
+        if (strpos($node->getFilename(), '.php') !== false) continue;
+        if( $node->isDot() ) continue;
+        if ( $node->isDir()) fillArrayWithFileNodes( new DirectoryIterator( $node->getPathname() ), $node->getPathname() );
+
+        $tmp = array(
+            "id" => $node->getPathname(),
+            "parent" => $theParent,
+            "text" => $node->getFilename(),
+        );
+        if ($node->isFile()) $tmp["icon"] = "file"; // can be path to icon file
+        $data[] = $tmp;
+    }
+}
+fillArrayWithFileNodes( new DirectoryIterator( '.' ) );
+
+// get all files in flat list
+$iter = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator('.', RecursiveDirectoryIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::SELF_FIRST,
+    RecursiveIteratorIterator::CATCH_GET_CHILD
+);
+$paths = array('.');
+foreach ($iter as $path => $dir) $paths[] = $path;
+
+// get number of directories
+$num_directories = 0;
+foreach ( (new DirectoryIterator('.')) as $node ) {
+    if( $node->isDot() ) continue;
+    if ( $node->isDir()) $num_directories += 1;
+}
+?>
+
+<script type="text/javascript">
+
+function contains_any(str, substrings) {
+    for (var i = 0; i != substrings.length; i++) {
+        var substring = substrings[i];
+        if (str.indexOf(substring) != - 1) {
+            return substring;
+        }
+    }
+    return null; 
+}
+
+function draw_objects(file_objects) {
+    $("#images").html("");
+    for (var ifo = 0; ifo < file_objects.length; ifo++) {
+        var fo = file_objects[ifo];
+        var name_noext = fo["name_noext"];
+        var name = fo["name"];
+        var path = fo["path"];
+        var color = fo["color"];
+        var pdf = fo["pdf"] || fo["name"];
+        if (path) pdf = path+pdf;
+        var pdf = escape(pdf);
+        var src = escape(path+"/"+name);
+        var txt_str = (fo["txt"].length > 0) ? `<span class='label label-rounded label-secondary' style='margin-left: 2px;'><a href='${fo["txt"]}' id='text_${fo["name_noext"]}'>text</a></span>` : "";
+        var extra_str = (fo["extra"].length > 0) ? `<span class='label label-rounded' style='margin-left: 2px;'><a href='${fo["extra"]}' id='extra_${fo["name_noext"]}'>extra</a></span>` : "";
+        var inner = `<img class='innerimg has-dark' loading='lazy' name='${name_noext}' src='${src}' height='300px' />`;
+        if (fo["onlypdf"]) {
+            inner = `<canvas class='innerimg has-dark' data-pdf-src='${pdf}' id='canv_${name_noext}' height='300px' ></canvas>`;
+        }
+        $("#images").append(`<div class='box' id='${name_noext}'>
+                    <fieldset class='has-dark'>
+                        <legend class='has-dark'>
+                            <span class='label label-rounded has-dark'>${name_noext}</span>
+                            ${txt_str+extra_str}
+                        </legend>
+                        <a href='${pdf}'>
+                            ${inner}
+                        </a>
+                    </fieldset>
+                </div>`);
+    }
+}
+
+function draw_filtered(filter_paths) {
+    var temp_filelist = filelist.filter(function(value) {
+            return contains_any(value, filter_paths);
+            });
+    var temp_objects = make_objects(temp_filelist);
+    draw_objects(temp_objects);
+}
+
+function make_objects(filelist) {
+    var good_exts = ["png", "svg", "gif", "jpeg", "jpg", "pdf"];
+    // basenames (ext stripped) for all files that are not .pdf
+    var basenonpdf = filelist.filter((f)=>!f.endsWith(".pdf")).map( (f,_)=>( f.split(".").slice(0, -1).join(".")   ) );
+    
+    var file_objects = [];
+    for (var i = 0; i < filelist.length; i++) {
+        var f = filelist[i];
+        var ext = f.split('.').pop();
+        // skip unknown extensions
+        if (!good_exts.includes(ext)) continue;
+
+        // if we have a pdf file that has a corresponding non-pdf file,
+        // then we skip the file if it is .pdf (otherwise we double count/render)
+        var basename = f.split(".").slice(0,-1).join(".");
+        var onlypdf = !basenonpdf.includes(basename);
+        if ((ext == "pdf") && !onlypdf) continue;
+
+        var color = "";
+        var name = f.split('/').reverse()[0];
+        var path = f.replace(name, "");
+        var name_noext = name.replace("."+ext,"");
+        var pdf = (filelist.indexOf(path+name_noext + ".pdf") != -1) ? name_noext+".pdf" : "";
+        var txt = (filelist.indexOf(path+name_noext + ".txt") != -1) ? name_noext+".txt" : "";
+        var extra = (filelist.indexOf(path+name_noext + ".extra") != -1) ? name_noext+".extra" : "";
+        var json = (filelist.indexOf(path+name_noext + ".json") != -1) ? name_noext+".json" : "";
+        file_objects.push({
+                "path": path,
+                "name_noext": name_noext,
+                "name":name,
+                "ext": ext,
+                "pdf": pdf,
+                "txt": txt,
+                "extra": extra,
+                "json": json,
+                "color": color,
+                "onlypdf": onlypdf,
+                });
+    }
+    // sort by name
+    file_objects.sort(function(a,b) { return a["name"] > b["name"]; });
+    return file_objects;
+}
+
+function register_hover() {
+    $("[id^=text_],[id^=extra_]").hover(
+        function() {
+            $(this).delay(500).queue(function(){
+                $(this).addClass('hovered').siblings().removeClass('hovered');
+                var link = $(this).attr('href');
+                $("#metadata").load(link, function() { });
+                $("#metadata").fadeIn();
+            });
+        },function() {
+            $(this).finish();
+            $("#metadata").delay(500).fadeOut();
+        } 
+    );
+}
+
+function register_description_hover() {
+    $("[class^=plot]").hover(
+        function() {
+            var plotname = $(this).text();
+            var plotselector = "#" + plotname;
+            $(plotselector).effect('highlight',{"color":"9d9"},500);
+            $(plotselector).finish();
+        },function() {
+        } 
+    );
+}
+
+function add_links_to_description(objects) {
+    var desc_src = $("#description").html();
+    for (var i = 0; i < objects.length; i++) {
+        var plotname = objects[i]["name_noext"];
+        desc_src = desc_src.split(plotname).join("<a href=\"#"+plotname+"\" class=\"plot\">"+plotname+"</a>");
+    }
+    $("#description").html(desc_src);
+}
+
+function enable_pdfjs() {
+    var elements = document.querySelectorAll("canvas[data-pdf-src]");
+    if (elements.length < 1) return;
+
+    var pdfjsLib = window['pdfjs-dist/build/pdf'];
+    pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.6.347/pdf.worker.min.js';
+
+    elements.forEach(function(element,idx) {
+        var canvasid = element.id;
+        var pdfurl = element.getAttribute("data-pdf-src");
+
+        var loadingTask = pdfjsLib.getDocument(pdfurl);
+        loadingTask.promise.then(function(pdf) {
+
+            pdf.getPage(1).then(function(page) {
+
+                var canvas = document.getElementById(canvasid);
+                var height = canvas.height;
+                var context = canvas.getContext("2d");
+                var viewport = page.getViewport({scale: 5});
+                canvas.width = viewport.width;
+                canvas.height = viewport.height;
+                canvas.style.height = height;
+
+                var renderContext = {
+                    canvasContext: context,
+                    viewport: viewport,
+                };
+                var renderTask = page.render(renderContext);
+                renderTask.promise.then(function () {
+                });
+            });
+        }, function (reason) {
+            // PDF loading error
+            console.error(reason);
+        });
+
+    });
+}
+// ultimately this will be a master filelist with all files recursively in this directory
+// then we will filter for files we want to show
+var obj = <?php echo json_encode($data); ?>;
+var filelist = <?php echo json_encode($paths); ?>;
+
+
+$(function() {
+
+    if (<?php echo $num_directories ?> > 0) {
+        $('#jstree_demo_div')
+            .on('changed.jstree', function(e,data) {
+                draw_filtered(data.selected);
+            })
+            .jstree( {
+                "core": {
+                    'multiple': true,
+                    'themes' : {
+                       'stripes' : true
+                    },
+                    "data": 
+                        obj
+                }
+            }); 
+    }
+
+    var markre = function(pattern) {
+        
+        var context=$("legend");
+        $("#message").html("");
+        $("#message").removeClass("label");
+        context.unmark();
+
+        var modifier = "";
+        if (pattern.toLowerCase() == pattern) modifier = "i"; // like :set smartcase in vim (case-sensitive if there's an uppercase char)
+
+        $(".form-icon").addClass("loading");
+
+        document.location.hash = escape($('#filter').val());
+        var regex = new RegExp(pattern,modifier);
+        context.markRegExp(regex,{
+            done: function(counter) {
+                $(".form-icon").removeClass("loading");
+                if (counter > 0) {
+                    // show all matches and hide those that don't match
+                    context.not(":has(mark)").parent().parent().hide();
+                    var toshow = context.has("mark").parent().parent();
+                    var nmatches = toshow.length;
+                    toshow.show();
+                    register_hover();
+                    $("#filterbadge").addClass("badge");
+                    $("#filterbadge").attr("data-badge",nmatches);
+                } else {
+                    context.parent().parent().show();
+                    if (pattern.length > 0) {
+                        $("#filterbadge").addClass("badge");
+                        $("#filterbadge").attr("data-badge",0);
+                    } else {
+                        $("#filterbadge").removeClass("badge");
+                    }
+                }
+            },
+        });
+    };
+
+    var timer;
+    var lastPattern = "";
+    var timeoutms = 300;
+    if (obj.length < 400) {
+        timeoutms = 0;
+    }
+    $("input[id='filter']").keyup(function(e) {
+        var pattern = $(this).val();
+        if (pattern == lastPattern) return;
+        if (lastPattern == "") {
+            lastPattern = this.value;
+            return;
+        } else {
+            lastPattern = this.value;
+        }
+        clearTimeout(timer);
+        timer = setTimeout(function() {
+            markre(lastPattern);
+        }, timeoutms);
+    });
+
+    var handle = $( "#custom-handle" );
+    // $("#slider").change(function() {
+    $("#slider").bind("input",function() {
+        var val = $(this).val();
+        $("img").attr("height",300*val/100);
+        $("canvas").attr("style",`height: ${300*val/100}px`);
+        if ((val == 0 && imagesVisible) || (val != 0 && !imagesVisible)) {
+            toggleImages();
+        }
+    });
+
+
+        var file_objects = make_objects(filelist);
+        draw_objects(file_objects);
+
+    // if page was loaded with a parameter for search, then simulate a search
+    // ex: https://foo.bar/plots_isfr_Aug26/#HH$
+     if(document.location.hash.length > 0) {
+        var search = unescape(document.location.hash.substring(1));
+        $("#filter").val(search);
+        markre($("#filter").val());
+    }
+
+    register_hover();
+    add_links_to_description(file_objects);
+    // register hover for links in description AFTER adding them
+    register_description_hover();
+    enable_pdfjs();
+
+    if (sessionStorage.getItem("darkMode") == 1) {
+        toggleDarkMode();
+    }
+
+});
+
+// vimlike incsearch: press / to focus on search box
+$(document).keydown(function(e) {
+    var modifierNoShift = e.metaKey || e.ctrlKey || e.altKey;
+    var modifier = e.shiftKey || modifierNoShift;
+    if(e.keyCode == 191 && !modifier) {
+        // / focus search box
+        e.preventDefault();
+        $("#filter").focus().select();
+    }
+    if (!$(event.target).is(":input")) {
+        if(e.keyCode== 89 && !modifier) {
+            // y
+            getQueryURL();
+        }
+        if(e.keyCode == 71 && !modifierNoShift) {
+            // G scrolls to bottom, g to top
+            if (e.shiftKey) {
+                window.scrollTo(0,document.body.scrollHeight);
+            } else {
+                window.scrollTo(0,0);
+            }
+        }
+        if(e.keyCode == 83 && !modifierNoShift) {
+            // s and shift S to sort a-z or z-a
+            if (e.shiftKey) {
+                $("#images").html($(".box").sort(function (a,b) { return $(a).attr("id").localeCompare($(b).attr("id")); }));
+            } else {
+                $("#images").html($(".box").sort(function (a,b) { return -$(a).attr("id").localeCompare($(b).attr("id")); }));
+            }
+        }
+        if(e.keyCode == 77 && !modifier) {
+            // m to toggle dark mode
+            toggleDarkMode();
+        }
+        if(e.keyCode == 66 && !modifier) {
+            // b to toggle super saturation mode
+            toggleSaturation();
+        }
+        if(e.keyCode == 88 && !modifier) {
+            // x to show and hide images
+            toggleImages();
+        }
+    }
+});
+
+function copyToClipboard(text) {
+    var $temp = $("<input>");
+    $("body").append($temp);
+    $temp.val(text).select();
+    document.execCommand("copy");
+    $temp.remove();
+    $("#message").html("Copied to clipboard!").delay(600).queue(function(n) {$(this).html("");n();});
+}
+
+function getQueryURL() {
+    copyToClipboard(location.href);
+}
+
+var darkMode = false;
+function toggleDarkMode() {
+    $(".has-dark").toggleClass("dark-mode");
+    // $(".legendname").toggleClass("label-secondary");
+    if (superSaturation) {
+        toggleSaturation();
+    }
+    darkMode ^= true;
+    if (darkMode) {
+        sessionStorage.setItem("darkMode", 1);
+    } else {
+        sessionStorage.setItem("darkMode", 0);
+    }
+}
+
+var superSaturation = false;
+function toggleSaturation() {
+    if (darkMode) {
+        $(".innerimg").toggleClass("dark-mode-super-saturate");
+    } else {
+        $(".innerimg").toggleClass("super-saturate");
+    }
+    superSaturation ^= true;
+}
+var imagesVisible = true;
+function toggleImages() {
+    $("img").toggle();
+    $("canvas").toggle();
+    $("fieldset").toggleClass("noborder");
+    imagesVisible ^= true;
+}
+
+</script>
+
+</head>
+
+<body class="has-dark">
+
+    <div id="container">
+
+        <div id="jstree_demo_div"> </div>
+
+        <div class="has-icon-right" style="width: 200px; display: inline-block;">
+            <input type="text" class="form-input input-sm inputbar has-dark" id="filter" placeholder="Search/filter" />
+            <span class="form-icon" id="filterbadge" data-badge=""></span>
+        </div>
+
+        &nbsp;
+
+
+        <div class="popover popover-bottom">
+            <button class="btn btn btn-sm has-dark">help</button>
+            <div class="popover-container">
+                <div class="card">
+                    <div class="card-header">
+                        Keybindings
+                    </div>
+                    <div class="card-body">
+                        <kbd>g</kbd> / <kbd>G</kbd> to scroll to top/bottom <br>
+                        <kbd>/</kbd> to focus the search box <br>
+                        <kbd>y</kbd> to copy the filter state as a URL <br>
+                        <kbd>s</kbd> / <kbd>S</kbd> to sort A-Z/Z-A <br>
+                        <kbd>b</kbd> to toggle super-saturation mode <br>
+                        <kbd>m</kbd> to toggle dark mode <br>
+                        <kbd>x</kbd> to toggle image visibility <br>
+                    </div>
+                    <div class="card-footer">
+                        <a href="https://github.com/aminnj/niceplots">View my source on GitHub</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        &nbsp;
+        <input id="slider" class="slider input-sm tooltip tooltip-bottom" type="range" min="0" max="300" value="100" oninput="this.setAttribute('value', this.value);">
+        <!-- <span id="message"></span> -->
+<div id="description">
+<?php
+$description = @file_get_contents("description.txt");
+if( $description ) {
+    echo "<br><b>Description:</b><br>";
+    echo $description;
+}
+?>
+</div>
+<div id="images"></div>
+<div id="metadatacontainer"  style="text-align: center;">
+<div id="metadata" style="display: inline-block; text-align: left; display: none">
+</div>
+</div>
+
+<canvas id='hovercanvas' width="50" height="300"></canvas>
+</div>
+
+
+</body>
+</html>
+


### PR DESCRIPTION
This PR addresses most of the remaining items on the to-do list in #18 

Summary:
- implement the option for an `AutoEncoder` to either (1) train a single autoencoder for all of its histograms or (2) train 1 autoencoder for each histogram. The latter is the new default option.
- fix bug that Kaitlin and Vivan encountered during `AutoEncoder.predict()` when training with labeled (i.e. good vs. bad) runs
- make `AnomalyDetectionAlgorithm` classes configurable through `json` inputs. In particular, this allows for a much smoother method of managing hyperparameters and training options for `AutoEncoder`s
- add SSE histograms on a per-events basis and a per-algorithm basis
- add SSE histograms split by good/bad runs
- add tools to calculate ROC curves, AUC, and their statistical uncertainties
- add tools to plot ROC curves and print efficiency values to tables

Usage of new features is documented in the [tutorial](https://autodqm.github.io/autodqm_ml.github.io/)